### PR TITLE
New function, write new privacy password on slix2 tags

### DIFF
--- a/PN5180ISO15693.h
+++ b/PN5180ISO15693.h
@@ -54,9 +54,11 @@ public:
   // ICODE SLIX2 specific commands, see https://www.nxp.com/docs/en/data-sheet/SL2S2602.pdf
   ISO15693ErrorCode getRandomNumber(uint8_t *randomData);
   ISO15693ErrorCode setPassword(uint8_t *password, uint8_t *random);
+  ISO15693ErrorCode writePassword(uint8_t *password, uint8_t *uid);
   ISO15693ErrorCode enablePrivacy(uint8_t *password, uint8_t *random);
   ISO15693ErrorCode unlockICODESLIX2(uint8_t *password);
   ISO15693ErrorCode lockICODESLIX2(uint8_t *password);
+  ISO15693ErrorCode newpasswordICODESLIX2(uint8_t *newpassword, uint8_t *oldpassword, uint8_t *uid);
   /*
    * Helper functions
    */

--- a/README.md
+++ b/README.md
@@ -1,43 +1,12 @@
 # PN5180-Library
 
-Arduino Uno / Arduino ESP-32 library for PN5180-NFC Module from NXP Semiconductors
+ESP-32 library for PN5180-NFC Module from NXP Semiconductors
 
-![PN5180-NFC module](./doc/PN5180-NFC.png)
-![PN5180 Schematics](./doc/FritzingLayout.jpg)
+Hardware: 
 
-Release Notes:
+Done: New Design of external Antenna. Reading Distance für Credit Card Size in Center of Antenna = 22cm
+In Work: Redsign of a 4W RF Ampfliefer for extend the read range up to 50cm.
 
-Version 1.6 - 13.03.2021
+Software:
 
-	* Added PN5180::writeEEPROM
-	
-Version 1.5 - 29.01.2020
-
-	* Fixed offset in readSingleBlock. Was off by 1.
-
-Version 1.4 - 13.11.2019
-
-	* ICODE SLIX2 specific commands, see https://www.nxp.com/docs/en/data-sheet/SL2S2602.pdf
-	* Example usage, currently outcommented
-
-Version 1.3 - 21.05.2019
-
-	* Initialized Reset pin with HIGH
-	* Made readBuffer static
-	* Typo fixes
-	* Data type corrections for length parameters
-
-Version 1.2 - 28.01.2019
-
-	* Cleared Option bit in PN5180ISO15693::readSingleBlock and ::writeSingleBlock
-
-Version 1.1 - 26.10.2018
-
-	* Cleanup, bug fixing, refactoring
-	* Automatic check for Arduino vs. ESP-32 platform via compiler switches
-	* Added open pull requests
-	* Working on documentation
-
-Version 1.0.x - 21.09.2018
-
-	* Initial versions
+In Work: Modify Library for ICODE-SLX2 to set new Privacy Password. Standard Password is 0F0F0F0Fh

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ ESP-32 library for PN5180-NFC Module from NXP Semiconductors
 Hardware: 
 
 Done: New Design of external Antenna. Reading Distance für Credit Card Size in Center of Antenna = 22cm
-In Work: Redsign of a 4W RF Ampfliefer for extend the read range up to 50cm.
+
+In Work: design of an 4W RF Ampfliefer for extend the read range up to 50cm.
 
 Software:
 

--- a/examples/PN5180-Library/PN5180-Library.ino
+++ b/examples/PN5180-Library/PN5180-Library.ino
@@ -163,6 +163,11 @@ void setup() {
 uint32_t loopCnt = 0;
 bool errorFlag = false;
 
+//SLIX2 Passwords, first is manufacture standard
+uint8_t standardpassword[] = {0x0F, 0x0F, 0x0F, 0x0F};
+//New Password
+uint8_t password[] = {0x12, 0x34, 0x56, 0x78};
+
 void loop() {
   if (errorFlag) {
     uint32_t irqStatus = nfc.getIRQStatus();
@@ -184,12 +189,26 @@ void loop() {
 
 /*
   // code for unlocking an ICODE SLIX2 protected tag   
-  uint8_t password[] = {0x5B, 0x6E, 0xFD, 0x7F};
   ISO15693ErrorCode myrc = nfc.unlockICODESLIX2(password);
   if (ISO15693_EC_OK == myrc) {
     Serial.println("unlockICODESLIX2 successful");
   }
 */
+  
+/* 
+  // code for set a new SLIX2 privacy password
+  nfc.getInventory(uid);
+  Serial.println("set new password"); 
+  
+  ISO15693ErrorCode myrc2 = nfc.newpasswordICODESLIX2(password, standardpassword, uid);
+  if (ISO15693_EC_OK == myrc2) { 
+   Serial.println("sucess! new password set");    
+  }else{
+   Serial.println("fail! no new password set: "); 
+   Serial.println(nfc.strerror(myrc2));  
+   Serial.println(" "); 
+  } 
+ */
   
   uint8_t uid[8];
   ISO15693ErrorCode rc = nfc.getInventory(uid);


### PR DESCRIPTION
Added the function for set a new privacy password. Standard is 0F0F0F0Fh.

With "newpasswordICODESLIX2(password, standardpassword, uid)" you can set a new password. 

Please Ignore the changes in Readme.md